### PR TITLE
Move to standard app_modeling database resource

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -30,7 +30,7 @@ define rgbank::db (
   }
 }
 
-Rgbank::Db produces Mysqldb {
+Rgbank::Db produces Database {
   database => "rgbank-${name}",
   user     => $user,
   host     => $ec2_metadata ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@ application rgbank (
     rgbank::db { $db_components[0]:
       user     => $db_username,
       password => $db_password,
-      export   => Mysqldb[$db_components[0]],
+      export   => Database[$db_components[0]],
     }
   }
 
@@ -24,13 +24,13 @@ application rgbank (
 
     if $vinfrastructure_components.size() > 0 {
       $vm = $comp_name.split('_')[0]
-      $rgbank_web_consume = [Mysqldb[$db_components[0]], Vinfrastructure[$vm]]
+      $rgbank_web_consume = [Database[$db_components[0]], Vinfrastructure[$vm]]
 
       rgbank::infrastructure::web { $vm:
         export => Vinfrastructure[$vm],
       }
     } else {
-     $rgbank_web_consume = Mysqldb[$db_components[0]]
+     $rgbank_web_consume = Database[$db_components[0]]
     }
 
     rgbank::web { $comp_name:

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -65,7 +65,7 @@ Rgbank::Web produces Http {
   host => $::fqdn,
 }
 
-Rgbank::Web consumes Mysqldb {
+Rgbank::Web consumes Database {
   db_name     => $database,
   db_host     => $host,
   db_user     => $user,

--- a/manifests/web/docker.pp
+++ b/manifests/web/docker.pp
@@ -30,7 +30,7 @@ Rgbank::Web produces Http {
   host => $::hostname,
 }
 
-Rgbank::Web consumes Mysqldb {
+Rgbank::Web consumes Database {
   db_name     => $database,
   db_host     => $host,
   db_user     => $user,


### PR DESCRIPTION
Previously, this relied on a custom module that has a custom
resource type called Mysqldb.  Moving this to using the database
resource type provided in our standard app_modeling module.